### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: learn-github-actions
 run-name: ${{ github.actor }} is learning GitHub Actions
+permissions:
+  contents: read
 on: [push]
 jobs:
   demo-nodejs-app:


### PR DESCRIPTION
Potential fix for [https://github.com/sreddzz/sample-nodejs/security/code-scanning/1](https://github.com/sreddzz/sample-nodejs/security/code-scanning/1)

In general, the fix is to explicitly specify a `permissions` block in the workflow or job so that the `GITHUB_TOKEN` is limited to the minimal required access. For this Node.js CI job, read access to repository contents is sufficient; no write scopes are needed.

The best minimal fix without changing functionality is to add `permissions: contents: read` at the workflow root (top level) so it applies to all jobs that don’t override it. Concretely, in `.github/workflows/main.yml`, insert a `permissions:` block just after the `run-name` (line 2) and before the `on:` key (line 3). No other lines or behavior need to change, and no imports or additional methods are required because this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
